### PR TITLE
gitignore.io and sphinx

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -181,6 +181,10 @@ var PythonLibraryGenerator = yeoman.Base.extend({
           projectName: this.projectName,
         }
       );
+      this.fs.copy(
+        this.templatePath('_setup.cfg'),
+        this.destinationPath('setup.cfg')
+      );
     },
 
     ciFiles: function () {

--- a/generators/app/templates/_requirements-dev.txt
+++ b/generators/app/templates/_requirements-dev.txt
@@ -1,4 +1,9 @@
-codecov>=1.6.3,<2
+autodoc>=0.3,<1.0.0
+codecov>=1.6.3,<2.0.0
 coverage>=4.0.3,<5.0.0
+docutils>=0.12,<1.0.0
+Jinja2>=2.8,<3.0.0
 tox>=1.8.0,<2.0.0
+Sphinx>=1.4.1,<2.0.0
+Sphinx-PyPI-upload>=0.2.1,<1
 virtualenv>=1.11.6,<2.0.0

--- a/generators/app/templates/_setup.cfg
+++ b/generators/app/templates/_setup.cfg
@@ -1,0 +1,7 @@
+[build_sphinx]
+source-dir = docs/source
+build-dir  = docs/build
+all_files  = 1
+
+[upload_sphinx]
+upload-dir = docs/build/html

--- a/generators/app/templates/_tox.ini
+++ b/generators/app/templates/_tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{32,33,34,35}, pypy, lint
+	py{27,35}, pypy, lint
 skip_missing_interpreters =
 	True
 

--- a/generators/app/templates/gitignore
+++ b/generators/app/templates/gitignore
@@ -5,3 +5,97 @@ __pycache__/
 /.coverage
 *.egg*
 *.pyc
+
+
+# Created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+


### PR DESCRIPTION
This pull request include the following 

items:
- added gitignore.io content (more comprehensive than current version)
- replaced py{32,33,34,35} with py{27,34} in_tox.ini (27 and 34 are easier to install on ubuntu than other Python versions). 

suggestions: 
- add optional sphinx support that works in similar way as ciProvider
- added _setup.cfg
- added sphinx related packages to _requirements-dev.txt